### PR TITLE
Remove browser tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Annotate html",
   "main": "lib/rough-notation.cjs.js",
   "module": "lib/rough-notation.esm.js",
-  "browser": "lib/rough-notation.iife.js",
   "types": "lib/rough-notation.d.ts",
   "scripts": {
     "build": "rm -rf lib && tsc && rollup -c",


### PR DESCRIPTION
Removes the browser tag as Webpack sees that as the default, though this code won't work when imported that way. The IIFE version is already available via unpkg. This addresses issue https://github.com/pshihn/rough-notation/issues/6.