### PR TITLE
docs: add link to website repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rough Notation uses [RoughJS](https://roughjs.com) to create a hand-drawn look a
 
 Rough Notation is about 3.2kb in size when gzipped.
 
-[Visit website to see it in action](https://roughnotation.com/)
+[Visit website to see it in action](https://roughnotation.com/) and check out the [source code](https://github.com/pshihn/rough-notation-web) for the website
 
 ## Installation
 


### PR DESCRIPTION
Adds link to the rough-notation website repo to the readme for the module 