### PR TITLE
Updating annotation

### DIFF
--- a/src/keyframes.ts
+++ b/src/keyframes.ts
@@ -1,6 +1,6 @@
 export function ensureKeyframes() {
-  if (!(window as any).__rough_notation_keyframe_styles) {
-    const style = (window as any).__rough_notation_keyframe_styles = document.createElement('style');
+  if (!(window as any).__rno_kf_s) {
+    const style = (window as any).__rno_kf_s = document.createElement('style');
     style.textContent = `@keyframes rough-notation-dash { to { stroke-dashoffset: 0; } }`;
     document.head.appendChild(style);
   }

--- a/src/keyframes.ts
+++ b/src/keyframes.ts
@@ -1,13 +1,7 @@
 export function ensureKeyframes() {
   if (!(window as any).__rough_notation_keyframe_styles) {
     const style = (window as any).__rough_notation_keyframe_styles = document.createElement('style');
-    style.textContent = `
-    @keyframes rough-notation-dash {
-      to {
-        stroke-dashoffset: 0;
-      }
-    }
-    `;
+    style.textContent = `@keyframes rough-notation-dash { to { stroke-dashoffset: 0; } }`;
     document.head.appendChild(style);
   }
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -13,8 +13,11 @@ export type RoughAnnotationType = 'underline' | 'box' | 'circle' | 'highlight' |
 export type FullPadding = [number, number, number, number];
 export type RoughPadding = number | [number, number] | FullPadding;
 
-export interface RoughAnnotationConfig {
+export interface RoughAnnotationConfig extends RoughAnnotationConfigBase {
   type: RoughAnnotationType;
+}
+
+export interface RoughAnnotationConfigBase {
   animate?: boolean; // defaults to true
   animationDuration?: number; // defaulst to 1000ms
   animationDelay?: number; // default = 0
@@ -24,7 +27,7 @@ export interface RoughAnnotationConfig {
   iterations?: number; // defaults to 2
 }
 
-export interface RoughAnnotation {
+export interface RoughAnnotation extends RoughAnnotationConfigBase {
   isShowing(): boolean;
   show(): void;
   hide(): void;

--- a/src/rough-notation.ts
+++ b/src/rough-notation.ts
@@ -124,12 +124,14 @@ class RoughAnnotationImpl implements RoughAnnotation {
         break;
       case 'showing':
         this.hide();
-        this.show();
+        if (this._svg) {
+          this.render(this._svg, true);
+        }
         break;
       case 'not-showing':
         this.attach();
         if (this._svg) {
-          this.render(this._svg);
+          this.render(this._svg, false);
         }
         break;
     }
@@ -153,10 +155,15 @@ class RoughAnnotationImpl implements RoughAnnotation {
     this.detachListeners();
   }
 
-  private render(svg: SVGSVGElement) {
+  private render(svg: SVGSVGElement, ensureNoAnimation: boolean) {
     const rect = this.computeSize();
     if (rect) {
-      renderAnnotation(svg, rect, this._config, this._animationGroupDelay);
+      let config = this._config;
+      if (ensureNoAnimation) {
+        config = JSON.parse(JSON.stringify(this._config));
+        config.animate = false;
+      }
+      renderAnnotation(svg, rect, config, this._animationGroupDelay);
       this._lastSize = rect;
       this._state = 'showing';
     }

--- a/src/rough-notation.ts
+++ b/src/rough-notation.ts
@@ -22,8 +22,40 @@ class RoughAnnotationImpl implements RoughAnnotation {
     this.attach();
   }
 
-  get config(): RoughAnnotationConfig {
-    return this._config;
+  get animate() { return this._config.animate; }
+  set animate(value) { this._config.animate = value; }
+
+  get animationDuration() { return this._config.animationDuration; }
+  set animationDuration(value) { this._config.animationDuration = value; }
+
+  get animationDelay() { return this._config.animationDelay; }
+  set animationDelay(value) { this._config.animationDelay = value; }
+
+  get iterations() { return this._config.iterations; }
+  set iterations(value) { this._config.iterations = value; }
+
+  get color() { return this._config.color; }
+  set color(value) {
+    if (this._config.color !== value) {
+      this._config.color = value;
+      this.refresh();
+    }
+  }
+
+  get strokeWidth() { return this._config.strokeWidth; }
+  set strokeWidth(value) {
+    if (this._config.strokeWidth !== value) {
+      this._config.strokeWidth = value;
+      this.refresh();
+    }
+  }
+
+  get padding() { return this._config.padding; }
+  set padding(value) {
+    if (this._config.padding !== value) {
+      this._config.padding = value;
+      this.refresh();
+    }
   }
 
   private _resizeListener = () => {
@@ -120,6 +152,18 @@ class RoughAnnotationImpl implements RoughAnnotation {
     return (this._state !== 'not-showing');
   }
 
+  private pendingRefresh?: Promise<void>;
+  private refresh() {
+    if (this.isShowing() && (!this.pendingRefresh)) {
+      this.pendingRefresh = Promise.resolve().then(() => {
+        if (this.isShowing()) {
+          this.show();
+        }
+        delete this.pendingRefresh;
+      });
+    }
+  }
+
   show(): void {
     switch (this._state) {
       case 'unattached':
@@ -200,7 +244,7 @@ export function annotationGroup(annotations: RoughAnnotation[]): RoughAnnotation
   for (const a of annotations) {
     const ai = a as RoughAnnotationImpl;
     ai._animationGroupDelay = delay;
-    const duration = ai.config.animationDuration === 0 ? 0 : (ai.config.animationDuration || DEFAULT_ANIMATION_DURATION);
+    const duration = ai.animationDuration === 0 ? 0 : (ai.animationDuration || DEFAULT_ANIMATION_DURATION);
     delay += duration;
   }
   const list = [...annotations];

--- a/src/rough-notation.ts
+++ b/src/rough-notation.ts
@@ -1,6 +1,7 @@
 import { Rect, RoughAnnotationConfig, RoughAnnotation, SVG_NS, RoughAnnotationGroup, DEFAULT_ANIMATION_DURATION } from './model.js';
 import { renderAnnotation } from './render.js';
 import { ensureKeyframes } from './keyframes.js';
+import { randomSeed } from 'roughjs/bin/math';
 
 type AnnotationState = 'unattached' | 'not-showing' | 'showing';
 
@@ -12,6 +13,7 @@ class RoughAnnotationImpl implements RoughAnnotation {
   private _resizing = false;
   private _resizeObserver?: any; // ResizeObserver is not supported in typescript std lib yet
   private _lastSize?: Rect;
+  private _seed = randomSeed();
   _animationGroupDelay = 0;
 
   constructor(e: HTMLElement, config: RoughAnnotationConfig) {
@@ -163,7 +165,7 @@ class RoughAnnotationImpl implements RoughAnnotation {
         config = JSON.parse(JSON.stringify(this._config));
         config.animate = false;
       }
-      renderAnnotation(svg, rect, config, this._animationGroupDelay);
+      renderAnnotation(svg, rect, config, this._animationGroupDelay, this._seed);
       this._lastSize = rect;
       this._state = 'showing';
     }


### PR DESCRIPTION
This changes a bunch of things. 

- When `show` is called when annotation is already showing, it does not re-animate the annotation just re-renders it . To re-animate, call `hide` and then call `show`. This addresses https://github.com/pshihn/rough-notation/issues/27 

- Annotation object now lets you update the color, strokeWidth, animationDuration, animationDelay, padding, animate, iterations property so you can change them after showing an annotation. This addresses https://github.com/pshihn/rough-notation/issues/16

- A seed is assigned to each annotation, so for every render, the hand-drawn randomness remains the same. 

