### PR TITLE
Add class name to injected SVG

### DIFF
--- a/src/rough-notation.ts
+++ b/src/rough-notation.ts
@@ -77,6 +77,7 @@ class RoughAnnotationImpl implements RoughAnnotation {
     if (this._state === 'unattached' && this._e.parentElement) {
       ensureKeyframes();
       const svg = this._svg = document.createElementNS(SVG_NS, 'svg');
+      svg.setAttribute('class', 'rough-annotation');
       const style = svg.style;
       style.position = 'absolute';
       style.top = '0';


### PR DESCRIPTION
Injected annotation SVG now has a class name `rough-annotation`. 
Fixes https://github.com/pshihn/rough-notation/issues/28