### PR TITLE
combineNestedSvgPaths not an option in roughjs

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -22,10 +22,10 @@ function getOptions(type: RoughOptionsType, seed: number): ResolvedOptions {
     dashOffset: -1,
     dashGap: -1,
     zigzagOffset: -1,
-    combineNestedSvgPaths: false,
+    seed: seed,
     disableMultiStroke: type !== 'double',
     disableMultiStrokeFill: false,
-    seed
+    preserveVertices: false
   };
 }
 


### PR DESCRIPTION
| Option                 	| Type    	|
|------------------------	|---------	|
| maxRandomnessOffset    	| number  	|
| roughness              	| number  	|
| bowing                 	| number  	|
| stroke                 	| string  	|
| strokeWidth            	| number  	|
| curveFitting           	| number  	|
| curveTightness         	| number  	|
| curveStepCount         	| number  	|
| fillStyle              	| string  	|
| fillWeight             	| number  	|
| hachureAngle           	| number  	|
| hachureGap             	| number  	|
| dashOffset             	| number  	|
| dashGap                	| number  	|
| zigzagOffset           	| number  	|
| seed                   	| number  	|
| randomizer?            	| Random  	|
| disableMultiStroke     	| boolean 	|
| disableMultiStrokeFill 	| boolean 	|
| preserveVertices       	| boolean 	|