### PR TITLE
added purescript wrapper for rough-notation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Others have created handy Rough Notation wrappers for multiple libraries and fra
 -   [Vue Rough Notation](https://github.com/Leecason/vue-rough-notation)
 -   [Web Component Rough Notation](https://github.com/Matsuuu/vanilla-rough-notation)
 -   [Angular Rough Notation](https://github.com/mikyaj/ngx-rough-notation)
+-   [Purescript Rough Notation](https://pursuit.purescript.org/packages/purescript-rough-notation/)
 
 ## Contributors
 


### PR DESCRIPTION
I recently created a purescript wrapper for rough notation, would you like to add it to the readme?